### PR TITLE
Fix build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ if [ -v sdl ]; then
         # @todo(mg): pass gcc/clang flag to SDL (is that even possible?)
         cd libs/SDL
         cmake -S . -B build -DSDL_SHARED=OFF -DSDL_STATIC=ON && cmake --build build
-        cd ..
+        cd ../../
     else
         echo "SDL directory not found! Make sure to initialize git submodules."
     fi


### PR DESCRIPTION
In build SDL path of building, scripts goes up two directories, but then only goes down one, remaining in wrong directory.